### PR TITLE
Fix missing available_io dir usage

### DIFF
--- a/cthulhu_src/services/cross_exchange_manager.py
+++ b/cthulhu_src/services/cross_exchange_manager.py
@@ -7,11 +7,21 @@ AVAILABLE_IO_DIR = expanduser("~/.cache/cthulhu/available_io")
 
 
 def get_free_transitions(exchanges):
-    input_avalible_currancy_files = [os.path.join(AVAILABLE_IO_DIR, f) for f in os.listdir(AVAILABLE_IO_DIR) if
-                                     (os.path.isfile(os.path.join(AVAILABLE_IO_DIR, f)) and f.endswith('_input.txt'))]
+    if not os.path.isdir(AVAILABLE_IO_DIR):
+        # directory with cached available currency lists does not exist
+        return []
 
-    output_avalible_currancy_files = [os.path.join(AVAILABLE_IO_DIR, f) for f in os.listdir(AVAILABLE_IO_DIR) if
-                                      (os.path.isfile(os.path.join(AVAILABLE_IO_DIR, f)) and f.endswith('_output.txt'))]
+    input_avalible_currancy_files = [
+        os.path.join(AVAILABLE_IO_DIR, f)
+        for f in os.listdir(AVAILABLE_IO_DIR)
+        if os.path.isfile(os.path.join(AVAILABLE_IO_DIR, f)) and f.endswith('_input.txt')
+    ]
+
+    output_avalible_currancy_files = [
+        os.path.join(AVAILABLE_IO_DIR, f)
+        for f in os.listdir(AVAILABLE_IO_DIR)
+        if os.path.isfile(os.path.join(AVAILABLE_IO_DIR, f)) and f.endswith('_output.txt')
+    ]
 
     pairs = []
     currency_out = []


### PR DESCRIPTION
## Summary
- handle missing cached available IO directory before reading currency lists

## Testing
- `python -m compileall -q cthulhu_src`

------
https://chatgpt.com/codex/tasks/task_e_6889e7f17cb4833395e2984ac04a0078