### PR TITLE
Add hourly CI with Telegram alerts

### DIFF
--- a/.github/workflows/hourly-test.yml
+++ b/.github/workflows/hourly-test.yml
@@ -1,0 +1,38 @@
+name: Hourly Tests
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+      CHAT_ID: ${{ secrets.CHAT_ID }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+      - name: Run tests
+        id: tests
+        run: |
+          pytest | tee pytest.log
+        continue-on-error: true
+      - name: Send result to Telegram
+        if: always()
+        run: |
+          if [ "${{ steps.tests.outcome }}" == "success" ]; then
+            STATUS="PASSED"
+          else
+            STATUS="FAILED"
+          fi
+          TEXT="Hourly tests ${STATUS}%0A$(tail -n 20 pytest.log | sed 's/%/%25/g; s/\n/%0A/g; s/\r/%0D/g')"
+          curl -s -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" -d chat_id="${CHAT_ID}" -d text="${TEXT}"


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs the tests each hour
- send test results to a Telegram bot via secrets `BOT_TOKEN` and `CHAT_ID`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688a60bbed64833384eafcced48c2e60