### PR TITLE
Fix TypeError when fetching order books

### DIFF
--- a/cthulhu_src/services/exchanges/base_exchange.py
+++ b/cthulhu_src/services/exchanges/base_exchange.py
@@ -55,7 +55,7 @@ class BaseExchange:
         result: Dict[
             str,
             Tuple[float, float],
-        ] = await self._with_proxy().fetch_order_book(symbol, limit=str(self.limit))
+        ] = await self._with_proxy().fetch_order_book(symbol, limit=self.limit)
 
         prices_bid = [
             Order(price=bid_price, amount=bid_amount)

--- a/cthulhu_src/services/exchanges/batching_exchange.py
+++ b/cthulhu_src/services/exchanges/batching_exchange.py
@@ -15,7 +15,7 @@ class BatchingExchange(BaseExchange):
                 str,
                 List[Tuple[float, float]],
             ],
-        ] = await self._with_proxy().fetch_order_books(symbols, limit=str(self.limit))
+        ] = await self._with_proxy().fetch_order_books(symbols, limit=self.limit)
 
         results = []
         for symbol, info in markets.items():


### PR DESCRIPTION
## Summary
- ensure integer `limit` is passed to ccxt when requesting order books

## Testing
- `make format`
- `make lint`
- `make test`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_688a7ab44c008333a5694eed89c13d57