### PR TITLE
Add hourly find command output to Telegram

### DIFF
--- a/.github/workflows/hourly-test.yml
+++ b/.github/workflows/hourly-test.yml
@@ -36,3 +36,13 @@ jobs:
           printf "Hourly tests %s\n" "$STATUS" > message.txt
           tail -n 20 pytest.log >> message.txt
           python ci/send_telegram.py < message.txt
+      - name: Run find command
+        if: always()
+        id: find
+        run: |
+          python -m cthulhu_src.main find -s binance_BTC | tee find.log
+        continue-on-error: true
+      - name: Send find result to Telegram
+        if: always()
+        run: |
+          python ci/send_telegram.py < find.log


### PR DESCRIPTION
## Summary
- update the hourly workflow to run `python -m cthulhu_src.main find -s binance_BTC`
- send the command result to Telegram

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a8d3278ec83339a2729ebe23a5673