### PR TITLE
Handle long telegram messages in CI script

### DIFF
--- a/ci/send_telegram.py
+++ b/ci/send_telegram.py
@@ -27,8 +27,13 @@ def get_chat_ids() -> set[str]:
     return chat_ids
 
 
+MAX_MESSAGE_LEN = 4096
+
+
 def send_message(chat_id: str, text: str) -> None:
-    api_call("sendMessage", {"chat_id": chat_id, "text": text})
+    """Send message to Telegram splitting it into chunks if needed."""
+    for i in range(0, len(text), MAX_MESSAGE_LEN):
+        api_call("sendMessage", {"chat_id": chat_id, "text": text[i : i + MAX_MESSAGE_LEN]})
 
 
 def main():

--- a/cthulhu_src/services/exchange_manager.py
+++ b/cthulhu_src/services/exchange_manager.py
@@ -1,5 +1,4 @@
 import asyncio
-import itertools
 import json
 import os
 import logging


### PR DESCRIPTION
## Summary
- avoid unused import in `exchange_manager`
- split telegram messages into smaller chunks to bypass API limits

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688a918945c08333a7a0cc17505e8234