### PR TITLE
Fix hourly workflow YAML

### DIFF
--- a/.github/workflows/hourly-test.yml
+++ b/.github/workflows/hourly-test.yml
@@ -36,12 +36,12 @@ jobs:
           printf "Hourly tests %s\n" "$STATUS" > message.txt
           tail -n 20 pytest.log >> message.txt
           python ci/send_telegram.py < message.txt
-        - name: Run find command
-          if: always()
-          id: find
-          run: |
-            python -m cthulhu_src.main find -s binance_BTC 2>&1 | tee find.log
-          continue-on-error: true
+      - name: Run find command
+        if: always()
+        id: find
+        run: |
+          python -m cthulhu_src.main find -s binance_BTC 2>&1 | tee find.log
+        continue-on-error: true
       - name: Send find result to Telegram
         if: always()
         run: |


### PR DESCRIPTION
## Summary
- fix YAML indentation of the `Run find command` step in hourly workflow

## Testing
- `make test`
- `yamllint .github/workflows/hourly-test.yml`


------
https://chatgpt.com/codex/tasks/task_e_688b210ee6488333bfaaec2bbd44e09f