### PR TITLE
Add advanced ML arbitrage ranking mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ exchange_list:
   - binance
   - hollaex
 ```
+```
 
 В формате JSON можно дополнительно указать список прокси:
 ```json
@@ -95,6 +96,27 @@ python -m cthulhu_src.main exchanges
 Получить перечень валют, доступных для ввода и вывода на конкретной бирже.
 ```bash
 python -m cthulhu_src.main available-io <exchange>
+```
+
+### Команда `predict`
+Эта команда использует логистическую регрессию по длине цепочки и потенциальной прибыли. При недостатке данных цепочки сортируются по коэффициенту прибыли.
+
+Поиск и ранжирование циклов с использованием простых ML‑методов.
+```bash
+python -m cthulhu_src.main predict -s <биржа_валюта> [опции]
+```
+
+### Команда `predict-advanced`
+Расширенный режим применяет случайный лес, анализируя также число уникальных бирж и валют и совпадение биржи начала и конца.
+
+Поиск и ранжирование циклов с использованием расширенных ML‑методов.
+```bash
+python -m cthulhu_src.main predict-advanced -s <биржа_валюта> [опции]
+```
+
+Пример:
+```bash
+python -m cthulhu_src.main predict-advanced -s binance_BTC -e binance -e hollaex
 ```
 
 Результаты сохраняются в `~/.cache/cthulhu/available_io`.

--- a/cthulhu_src/actions/predict_advanced.py
+++ b/cthulhu_src/actions/predict_advanced.py
@@ -1,0 +1,119 @@
+import logging
+from collections import defaultdict
+
+from cthulhu_src.services.exchange_manager import ExchangeManager
+from cthulhu_src.services.processor import find_paths
+from cthulhu_src.services.arbitrage import find_paths_bellman_ford
+from cthulhu_src.services.exchanges.batching_exchange import BatchingExchange
+from cthulhu_src.services.cross_exchange_manager import get_free_transitions
+from cthulhu_src.services.predict import rank_paths_advanced
+
+"""Advanced ML-based ranking of arbitrage chains."""
+
+
+async def run(
+    ctx,
+    max_depth: int,
+    exchange_list: list,
+    start_node: str,
+    start_amount: float,
+    cache_dir: str,
+    current_node: str | None = None,
+    current_amount: float | None = None,
+    cached: bool = False,
+    algorithm: str = "dfs",
+    processes: int | None = None,
+    prune_ratio: float = 0.0,
+    batch_size: int = 20,
+    proxy: tuple | list = (),
+):
+    """Run search and rank resulting chains using advanced ML."""
+
+    log = logging.getLogger("excthulhu")
+    log.info(
+        f"🤖 Advanced predicting with max depth {max_depth} for exchanges: {', '.join(exchange_list)}"
+    )
+
+    log.info("⬇️ Start loading data...")
+
+    BatchingExchange.max_batch_size = batch_size
+    exchange_manager = ExchangeManager(
+        exchange_list, proxy, cached=cached, cache_dir=cache_dir
+    )
+    try:
+        pairs = await exchange_manager.fetch_prices()
+    finally:
+        await exchange_manager.close()
+
+    pairs += get_free_transitions(exchange_list)
+
+    log.info("✅ Finish loading")
+
+    log.info("⚙️ Start prepare data...")
+
+    adj_dict = defaultdict(list)
+    for pair in pairs:
+        adj_dict[pair.currency_from].append(pair)
+
+    currency_list = list(adj_dict.keys())
+
+    adj_list = [
+        {
+            currency_list.index(pair.currency_to): pair.trade_book
+            for pair in adj_dict[currency_from]
+        }
+        for currency_from in currency_list
+    ]
+
+    current_node_id = None
+    if current_node:
+        if current_node not in currency_list:
+            log.error(
+                f"❌ Current node {current_node} is not available in fetched data."
+            )
+            return
+        current_node_id = currency_list.index(current_node)
+
+    log.info("✅ Finish prepare data")
+
+    if start_node not in currency_list:
+        log.error(f"❌ Start node {start_node} is not available in fetched data.")
+        return
+
+    log.info("🔄 Start data processing...")
+    if algorithm == "bellman-ford":
+        paths = find_paths_bellman_ford(
+            adj_list=adj_list,
+            start_node=currency_list.index(start_node),
+            start_amount=start_amount,
+        )
+    else:
+        paths = find_paths(
+            adj_list=adj_list,
+            start_node=currency_list.index(start_node),
+            start_amount=start_amount,
+            current_node=current_node_id,
+            current_amount=current_amount,
+            max_depth=max_depth,
+            prune_ratio=prune_ratio,
+            num_workers=processes,
+        )
+    log.info("✅ Finish data processing")
+
+    ranked = rank_paths_advanced(paths, start_amount, currency_list)
+
+    result = [
+        (score, [(currency_list[node[0]], node[1]) for node in path])
+        for score, path in ranked
+    ]
+
+    for score, path in result:
+        print(
+            f"score={score:.3f}",
+            *[f"{node[0]} ({node[1]})" for node in path],
+            sep=" -> ",
+            end="",
+        )
+        print(f" = {(path[-1][1] / start_amount - 1) * 100}%")
+
+    log.info(f"🏆 Total count of ranked cycles:{len(result)}")

--- a/cthulhu_src/actions/predict_txn.py
+++ b/cthulhu_src/actions/predict_txn.py
@@ -1,0 +1,118 @@
+import logging
+from collections import defaultdict
+
+from cthulhu_src.services.exchange_manager import ExchangeManager
+from cthulhu_src.services.processor import find_paths
+from cthulhu_src.services.arbitrage import find_paths_bellman_ford
+from cthulhu_src.services.exchanges.batching_exchange import BatchingExchange
+from cthulhu_src.services.cross_exchange_manager import get_free_transitions
+from cthulhu_src.services.predict import rank_paths_ml
+
+"""ML-based ranking of arbitrage chains."""
+
+
+async def run(
+    ctx,
+    max_depth: int,
+    exchange_list: list,
+    start_node: str,
+    start_amount: float,
+    cache_dir: str,
+    current_node: str | None = None,
+    current_amount: float | None = None,
+    cached: bool = False,
+    algorithm: str = "dfs",
+    processes: int | None = None,
+    prune_ratio: float = 0.0,
+    batch_size: int = 20,
+    proxy: tuple | list = (),
+):
+    """Run search and rank resulting chains using ML."""
+    log = logging.getLogger("excthulhu")
+    log.info(
+        f'🤖 Predicting transactions with max depth {max_depth} for exchanges: {", ".join(exchange_list)}'
+    )
+
+    log.info("⬇️ Start loading data...")
+
+    BatchingExchange.max_batch_size = batch_size
+    exchange_manager = ExchangeManager(
+        exchange_list, proxy, cached=cached, cache_dir=cache_dir
+    )
+    try:
+        pairs = await exchange_manager.fetch_prices()
+    finally:
+        await exchange_manager.close()
+
+    pairs += get_free_transitions(exchange_list)
+
+    log.info("✅ Finish loading")
+
+    log.info("⚙️ Start prepare data...")
+
+    adj_dict = defaultdict(list)
+    for pair in pairs:
+        adj_dict[pair.currency_from].append(pair)
+
+    currency_list = list(adj_dict.keys())
+
+    adj_list = [
+        {
+            currency_list.index(pair.currency_to): pair.trade_book
+            for pair in adj_dict[currency_from]
+        }
+        for currency_from in currency_list
+    ]
+
+    current_node_id = None
+    if current_node:
+        if current_node not in currency_list:
+            log.error(
+                f"❌ Current node {current_node} is not available in fetched data."
+            )
+            return
+        current_node_id = currency_list.index(current_node)
+
+    log.info("✅ Finish prepare data")
+
+    if start_node not in currency_list:
+        log.error(f"❌ Start node {start_node} is not available in fetched data.")
+        return
+
+    log.info("🔄 Start data processing...")
+    if algorithm == "bellman-ford":
+        paths = find_paths_bellman_ford(
+            adj_list=adj_list,
+            start_node=currency_list.index(start_node),
+            start_amount=start_amount,
+        )
+    else:
+        paths = find_paths(
+            adj_list=adj_list,
+            start_node=currency_list.index(start_node),
+            start_amount=start_amount,
+            current_node=current_node_id,
+            current_amount=current_amount,
+            max_depth=max_depth,
+            prune_ratio=prune_ratio,
+            num_workers=processes,
+        )
+    log.info("✅ Finish data processing")
+
+    ranked = rank_paths_ml(paths, start_amount)
+
+    result = [
+        (score, [(currency_list[node[0]], node[1]) for node in path])
+        for score, path in ranked
+    ]
+
+    for score, path in result:
+        print(
+            f"score={score:.3f}",
+            *[f"{node[0]} ({node[1]})" for node in path],
+            sep=" -> ",
+            end="",
+        )
+        print(f" = {(path[-1][1] / start_amount - 1) * 100}%")
+
+    log.info(f"🏆 Total count of ranked cycles:{len(result)}")

--- a/cthulhu_src/main.py
+++ b/cthulhu_src/main.py
@@ -13,6 +13,8 @@ from cthulhu_src.routes.config import config
 from cthulhu_src.routes.find_txn import find
 from cthulhu_src.routes.exchanges import exchanges
 from cthulhu_src.routes.available_io import available_io
+from cthulhu_src.routes.predict_txn import predict
+from cthulhu_src.routes.predict_advanced_txn import predict_advanced
 
 
 @click.group()
@@ -26,6 +28,8 @@ cli.add_command(find)
 cli.add_command(config)
 cli.add_command(exchanges)
 cli.add_command(available_io)
+cli.add_command(predict)
+cli.add_command(predict_advanced)
 
 
 def main():

--- a/cthulhu_src/routes/predict_advanced_txn.py
+++ b/cthulhu_src/routes/predict_advanced_txn.py
@@ -1,0 +1,73 @@
+import click
+import asyncio
+from cthulhu_src.actions.predict_advanced import run as run_cmd
+
+"""CLI command for advanced ML-based ranking of cycles."""
+
+HELP_MAX_DEPTH = "Max depth of transaction exchange and transfer."
+HELP_START = "Currency and Exchange Entry Point"
+HELP_AMOUNT = "Amount of starting currency"
+HELP_CACHED = "Cache exchange data"
+HELP_CURRENT_NODE = "Currency and Exchange where you stopped"
+HELP_CURRENT_AMOUNT = "Amount of currency where you stop"
+HELP_CACHED_DIR = "Path to folder with cached exchange data. Default: ~/.cache/cthulhu"
+HELP_ALGO = "Algorithm for search: dfs or bellman-ford"
+HELP_PROCESSES = "Number of worker processes for DFS"
+HELP_PRUNE = "Prune ratio for DFS pruning"
+HELP_BATCH = "Batch size when fetching order books"
+
+
+@click.command(name="predict-advanced")
+@click.pass_context
+@click.option("-d", "--max-depth", type=int, default=4, help=HELP_MAX_DEPTH)
+@click.option("-s", "--start", required=True, help=HELP_START)
+@click.option("-a", "--amount", type=float, default=1.0, help=HELP_AMOUNT)
+@click.option(
+    "-c", "--cached", type=bool, default=False, help=HELP_CACHED, is_flag=True
+)
+@click.option("--cache-dir", default="~/.cache/cthulhu", help=HELP_CACHED_DIR)
+@click.option("-e", "--exchange-list", multiple=True, default=["yobit", "binance"])
+@click.option("--current-node", required=False, help=HELP_CURRENT_NODE)
+@click.option("--current-amount", required=False, type=float, help=HELP_CURRENT_AMOUNT)
+@click.option(
+    "--algorithm",
+    type=click.Choice(["dfs", "bellman-ford"]),
+    default="dfs",
+    help=HELP_ALGO,
+)
+@click.option("--processes", type=int, default=None, help=HELP_PROCESSES)
+@click.option("--prune-ratio", type=float, default=0.0, help=HELP_PRUNE)
+@click.option("--batch-size", type=int, default=20, help=HELP_BATCH)
+def predict_advanced(
+    ctx,
+    max_depth,
+    start,
+    amount,
+    cached,
+    cache_dir,
+    exchange_list,
+    current_node,
+    current_amount,
+    algorithm,
+    processes,
+    prune_ratio,
+    batch_size,
+):
+    """Rank cycles using advanced ML predictions."""
+    asyncio.run(
+        run_cmd(
+            ctx,
+            max_depth,
+            exchange_list,
+            start,
+            amount,
+            cache_dir,
+            current_node,
+            current_amount,
+            cached,
+            algorithm,
+            processes,
+            prune_ratio,
+            batch_size,
+        )
+    )

--- a/cthulhu_src/routes/predict_txn.py
+++ b/cthulhu_src/routes/predict_txn.py
@@ -1,0 +1,73 @@
+import click
+import asyncio
+from cthulhu_src.actions.predict_txn import run as run_cmd
+
+"""Command for ML-based ranking of cycles."""
+
+HELP_MAX_DEPTH = "Max depth of transaction exchange and transfer."
+HELP_START = "Currency and Exchange Entry Point"
+HELP_AMOUNT = "Amount of starting currency"
+HELP_CACHED = "Cache exchange data"
+HELP_CURRENT_NODE = "Currency and Exchange where you stopped"
+HELP_CURRENT_AMOUNT = "Amount of currency where you stop"
+HELP_CACHED_DIR = "Path to folder with cached exchange data. Default: ~/.cache/cthulhu"
+HELP_ALGO = "Algorithm for search: dfs or bellman-ford"
+HELP_PROCESSES = "Number of worker processes for DFS"
+HELP_PRUNE = "Prune ratio for DFS pruning"
+HELP_BATCH = "Batch size when fetching order books"
+
+
+@click.command()
+@click.pass_context
+@click.option("-d", "--max-depth", type=int, default=4, help=HELP_MAX_DEPTH)
+@click.option("-s", "--start", required=True, help=HELP_START)
+@click.option("-a", "--amount", type=float, default=1.0, help=HELP_AMOUNT)
+@click.option(
+    "-c", "--cached", type=bool, default=False, help=HELP_CACHED, is_flag=True
+)
+@click.option("--cache-dir", default="~/.cache/cthulhu", help=HELP_CACHED_DIR)
+@click.option("-e", "--exchange-list", multiple=True, default=["yobit", "binance"])
+@click.option("--current-node", required=False, help=HELP_CURRENT_NODE)
+@click.option("--current-amount", required=False, type=float, help=HELP_CURRENT_AMOUNT)
+@click.option(
+    "--algorithm",
+    type=click.Choice(["dfs", "bellman-ford"]),
+    default="dfs",
+    help=HELP_ALGO,
+)
+@click.option("--processes", type=int, default=None, help=HELP_PROCESSES)
+@click.option("--prune-ratio", type=float, default=0.0, help=HELP_PRUNE)
+@click.option("--batch-size", type=int, default=20, help=HELP_BATCH)
+def predict(
+    ctx,
+    max_depth,
+    start,
+    amount,
+    cached,
+    cache_dir,
+    exchange_list,
+    current_node,
+    current_amount,
+    algorithm,
+    processes,
+    prune_ratio,
+    batch_size,
+):
+    """Rank cycles using ML predictions."""
+    asyncio.run(
+        run_cmd(
+            ctx,
+            max_depth,
+            exchange_list,
+            start,
+            amount,
+            cache_dir,
+            current_node,
+            current_amount,
+            cached,
+            algorithm,
+            processes,
+            prune_ratio,
+            batch_size,
+        )
+    )

--- a/cthulhu_src/services/predict.py
+++ b/cthulhu_src/services/predict.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+"""Simple ML-based ranking of arbitrage paths."""
+
+from typing import List, Tuple
+
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import RandomForestClassifier
+
+from .processor import Path
+
+
+def rank_paths_ml(paths: List[Path], start_amount: float) -> List[Tuple[float, Path]]:
+    """Rank arbitrage ``paths`` using a logistic regression model.
+
+    The model is trained on the fly using path length and profit ratio as
+    features. The function returns a list of ``(score, path)`` tuples sorted
+    by descending score.
+    """
+
+    if not paths:
+        return []
+
+    features = []
+    labels = []
+    for path in paths:
+        profit_ratio = path[-1][1] / start_amount
+        features.append([len(path), profit_ratio])
+        labels.append(1 if profit_ratio > 1.0 else 0)
+
+    X = np.array(features)
+    y = np.array(labels)
+
+    if len(paths) > 1 and len(set(labels)) > 1:
+        model = LogisticRegression()
+        model.fit(X, y)
+        scores = model.predict_proba(X)[:, 1]
+    else:
+        # fallback to profit ratio if there is not enough data for training
+        scores = X[:, 1]
+
+    ranked = sorted(zip(scores, paths), key=lambda x: x[0], reverse=True)
+    return ranked
+
+
+def rank_paths_advanced(
+    paths: List[Path], start_amount: float, currency_list: List[str]
+) -> List[Tuple[float, Path]]:
+    """Rank arbitrage ``paths`` using a random forest model with extra features."""
+
+    if not paths:
+        return []
+
+    features: List[List[float]] = []
+    labels: List[int] = []
+
+    for path in paths:
+        profit_ratio = path[-1][1] / start_amount
+
+        exchanges = set()
+        currencies = set()
+        for step in path:
+            name = currency_list[step[0]]
+            if "_" in name:
+                ex, cur = name.split("_", 1)
+            else:
+                ex, cur = "", name
+            exchanges.add(ex)
+            currencies.add(cur)
+
+        start_ex = currency_list[path[0][0]].split("_", 1)[0]
+        end_ex = currency_list[path[-1][0]].split("_", 1)[0]
+
+        features.append(
+            [
+                len(path),
+                profit_ratio,
+                len(exchanges),
+                len(currencies),
+                1.0 if start_ex == end_ex else 0.0,
+            ]
+        )
+        labels.append(1 if profit_ratio > 1.0 else 0)
+
+    X = np.array(features)
+    y = np.array(labels)
+
+    if len(paths) > 1 and len(set(labels)) > 1:
+        model = RandomForestClassifier(n_estimators=50)
+        model.fit(X, y)
+        scores = model.predict_proba(X)[:, 1]
+    else:
+        # fallback to profit ratio if there is not enough data for training
+        scores = X[:, 1]
+
+    ranked = sorted(zip(scores, paths), key=lambda x: x[0], reverse=True)
+    return ranked

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ tqdm = "^4.46.0"
 pyyaml = "^5.3.1"
 aiohttp_proxy = "^0.1.2"
 aiohttp = "^3.6.2"
+numpy = "^2.3"
+scikit-learn = "^1.7"
 
 [tool.poetry.dev-dependencies]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ aiohttp
 aiohttp_proxy
 pyyaml
 tqdm
+numpy
+scikit-learn

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1,0 +1,24 @@
+from cthulhu_src.services.predict import rank_paths_ml, rank_paths_advanced
+
+
+def test_rank_paths_ml_ordering():
+    start_amount = 1.0
+    path_good = [(0, 1.0), (1, 2.0), (0, 1.5)]
+    path_bad = [(0, 1.0), (1, 0.5), (0, 0.25)]
+
+    ranked = rank_paths_ml([path_bad, path_good], start_amount)
+
+    assert ranked[0][1] == path_good
+    assert len(ranked) == 2
+
+
+def test_rank_paths_advanced_ordering():
+    start_amount = 1.0
+    path_good = [(0, 1.0), (1, 2.0), (0, 1.5)]
+    path_bad = [(0, 1.0), (1, 0.5), (0, 0.25)]
+    currency_list = ["ex1_BTC", "ex1_USDT"]
+
+    ranked = rank_paths_advanced([path_bad, path_good], start_amount, currency_list)
+
+    assert ranked[0][1] == path_good
+    assert len(ranked) == 2


### PR DESCRIPTION
## Summary
- introduce `rank_paths_advanced` using random forest and extra features
- add new `predict-advanced` command and integrate into CLI
- document the command in README
- test advanced ranking
- clarify README usage for the new mode

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688cb0776ccc83339fd45b9289f322f4