### PR TITLE
Add ARIMA forecasting method

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,24 @@ python -m cthulhu_src.main available-io <exchange>
 
 Результаты сохраняются в `~/.cache/cthulhu/available_io`.
 
+### Команда `forecast`
+
+Базовый прогноз цен на основе окна лог-доходностей. Поддерживает несколько методов предикта (mean, median, ema, arima).
+
+```bash
+python -m cthulhu_src.main forecast --prices 1,2,4,8 --horizons 1,5 --methods mean,arima
+```
+
+### Команда `forecast-backtest`
+
+Проверка, принесла бы прибыль сделка, совершённая в прошлом. По умолчанию
+используется временной сдвиг **120 минут**, но его можно задать вручную.
+
+```bash
+python -m cthulhu_src.main forecast-backtest --prices 1,2,4,8,16 --horizon 5 \
+    --minutes-back 180
+```
+
 ## Архитектура проекта
 
 ```

--- a/cthulhu_src/actions/forecast.py
+++ b/cthulhu_src/actions/forecast.py
@@ -1,0 +1,15 @@
+from cthulhu_src.services.forecast import ForecastService
+
+
+def run(ctx, prices: str, horizons: str, lookback: int, methods: str) -> None:
+    price_list = [float(p) for p in prices.split(",") if p]
+    horizon_list = [int(h) for h in horizons.split(",") if h]
+    method_list = [m.strip() for m in methods.split(",") if m]
+    service = ForecastService(lookback=lookback)
+    results = service.predict_many(price_list, horizon_list, method_list)
+    for method, forecasts in results.items():
+        print(f"method: {method}")
+        for fc in forecasts:
+            print(
+                f"  h={fc.h} mu={fc.mu:.6f} sigma={fc.sigma:.6f} q10={fc.q10:.6f} q50={fc.q50:.6f} q90={fc.q90:.6f}"
+            )

--- a/cthulhu_src/actions/forecast_backtest.py
+++ b/cthulhu_src/actions/forecast_backtest.py
@@ -1,0 +1,8 @@
+from cthulhu_src.services.forecast import ForecastService
+
+
+def run(ctx, prices: str, horizon: int, lookback: int, minutes_back: int) -> None:
+    price_list = [float(p) for p in prices.split(",") if p]
+    svc = ForecastService(lookback=lookback)
+    success = svc.backtest(price_list, horizon, minutes_back=minutes_back)
+    print("profitable" if success else "not profitable")

--- a/cthulhu_src/main.py
+++ b/cthulhu_src/main.py
@@ -13,6 +13,8 @@ from cthulhu_src.routes.config import config
 from cthulhu_src.routes.find_txn import find
 from cthulhu_src.routes.exchanges import exchanges
 from cthulhu_src.routes.available_io import available_io
+from cthulhu_src.routes.forecast import forecast
+from cthulhu_src.routes.forecast_backtest import forecast_backtest
 
 
 @click.group()
@@ -26,6 +28,8 @@ cli.add_command(find)
 cli.add_command(config)
 cli.add_command(exchanges)
 cli.add_command(available_io)
+cli.add_command(forecast)
+cli.add_command(forecast_backtest)
 
 
 def main():

--- a/cthulhu_src/routes/forecast.py
+++ b/cthulhu_src/routes/forecast.py
@@ -1,0 +1,21 @@
+import click
+from cthulhu_src.actions.forecast import run as run_cmd
+
+
+@click.command()
+@click.option("--prices", required=True, help="Comma separated price list")
+@click.option(
+    "--horizons",
+    default="1,5,15,60",
+    help="Comma separated forecast horizons",
+)
+@click.option("--lookback", default=60, type=int, help="Lookback window")
+@click.option(
+    "--methods",
+    default="mean",
+    help="Comma separated prediction methods (mean, median, ema)",
+)
+@click.pass_context
+def forecast(ctx, prices: str, horizons: str, lookback: int, methods: str) -> None:
+    """Calculate naive forecasts for given prices."""
+    run_cmd(ctx, prices, horizons, lookback, methods)

--- a/cthulhu_src/routes/forecast_backtest.py
+++ b/cthulhu_src/routes/forecast_backtest.py
@@ -1,0 +1,20 @@
+import click
+from cthulhu_src.actions.forecast_backtest import run as run_cmd
+
+
+@click.command()
+@click.option("--prices", required=True, help="Comma separated price list")
+@click.option("--horizon", default=5, type=int, help="Forecast horizon")
+@click.option("--lookback", default=60, type=int, help="Lookback window")
+@click.option(
+    "--minutes-back",
+    default=120,
+    type=int,
+    help="How many minutes ago to simulate the trade",
+)
+@click.pass_context
+def forecast_backtest(
+    ctx, prices: str, horizon: int, lookback: int, minutes_back: int
+) -> None:
+    """Check trade profitability ``minutes_back`` minutes in the past."""
+    run_cmd(ctx, prices, horizon, lookback, minutes_back)

--- a/cthulhu_src/services/__init__.py
+++ b/cthulhu_src/services/__init__.py
@@ -1,1 +1,5 @@
 """Service layer with data structures and processing utilities."""
+
+from .forecast import ForecastService, Forecast
+
+__all__ = ["ForecastService", "Forecast"]

--- a/cthulhu_src/services/forecast.py
+++ b/cthulhu_src/services/forecast.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence
+import numpy as np
+import statsmodels.api as sm
+from scipy.stats import norm
+
+
+@dataclass
+class Forecast:
+    """Container for forecast statistics."""
+
+    h: int
+    mu: float
+    sigma: float
+    q10: float
+    q50: float
+    q90: float
+
+
+class ForecastService:
+    """Forecasting service using simple statistics or ARIMA model."""
+
+    SUPPORTED_METHODS = ("mean", "median", "ema", "arima")
+
+    def __init__(self, lookback: int = 60) -> None:
+        self.lookback = lookback
+
+    def predict(
+        self, prices: Iterable[float], horizons: Iterable[int], method: str = "mean"
+    ) -> List[Forecast]:
+        if method not in self.SUPPORTED_METHODS:
+            raise ValueError(f"unknown method {method}")
+
+        prices_list = list(prices)
+        if not prices_list:
+            raise ValueError("prices sequence is empty")
+        max_h = max(horizons)
+        required = self.lookback + max_h
+        if len(prices_list) < required:
+            raise ValueError("not enough price history for given lookback and horizon")
+
+        log_prices = np.log(np.asarray(prices_list, dtype=float))
+        returns = np.diff(log_prices)
+
+        forecasts: List[Forecast] = []
+        for h in horizons:
+            window = returns[-(self.lookback + h - 1) :]
+            r_h = window[-h:]
+
+            if method == "mean":
+                mu = float(np.mean(r_h))
+            elif method == "median":
+                mu = float(np.median(r_h))
+            elif method == "ema":
+                weights = np.exp(np.linspace(-1.0, 0.0, len(r_h)))
+                weights /= weights.sum()
+                mu = float(np.dot(weights, r_h))
+            elif method == "arima":
+                model = sm.tsa.ARIMA(window, order=(1, 0, 0)).fit()
+                fc = model.get_forecast(steps=h)
+                mu = float(np.sum(fc.predicted_mean))
+                sigma = float(np.sqrt(np.sum(fc.var_pred_mean)))
+                z10, z90 = norm.ppf([0.1, 0.9])
+                q10 = mu + z10 * sigma
+                q50 = mu
+                q90 = mu + z90 * sigma
+                forecasts.append(
+                    Forecast(h=int(h), mu=mu, sigma=sigma, q10=q10, q50=q50, q90=q90)
+                )
+                continue
+
+            sigma = float(np.std(r_h, ddof=1)) if len(r_h) > 1 else 0.0
+            q10, q50, q90 = np.quantile(r_h, [0.1, 0.5, 0.9])
+
+            forecasts.append(
+                Forecast(
+                    h=int(h),
+                    mu=mu,
+                    sigma=sigma,
+                    q10=float(q10),
+                    q50=float(q50),
+                    q90=float(q90),
+                )
+            )
+        return forecasts
+
+    def predict_many(
+        self,
+        prices: Sequence[float],
+        horizons: Sequence[int],
+        methods: Sequence[str],
+    ) -> Dict[str, List[Forecast]]:
+        """Run several prediction methods and gather their results."""
+
+        results: Dict[str, List[Forecast]] = {}
+        for m in methods:
+            results[m] = self.predict(prices, horizons, method=m)
+        return results
+
+    def backtest(
+        self, prices: Iterable[float], horizon: int, minutes_back: int = 120
+    ) -> bool:
+        """Evaluate a trade placed ``minutes_back`` minutes ago.
+
+        Parameters
+        ----------
+        prices:
+            Sequence of historical prices ordered oldest to newest. Prices must
+            contain the window used for training and the period to backtest.
+        horizon:
+            Forecast horizon in minutes for the simulated trade.
+        minutes_back:
+            How many minutes in the past to start the trade. By default two
+            hours (120 minutes).
+        """
+        prices_list = list(prices)
+        required = self.lookback + horizon + minutes_back
+        if len(prices_list) < required:
+            raise ValueError("not enough price history for backtest")
+
+        start_idx = len(prices_list) - minutes_back
+        forecast = self.predict(prices_list[:start_idx], [horizon])[0]
+        if forecast.mu <= 0:
+            return False
+        log_ret = float(
+            np.log(prices_list[start_idx + horizon] / prices_list[start_idx])
+        )
+        return log_ret > 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ tqdm = "^4.46.0"
 pyyaml = "^5.3.1"
 aiohttp_proxy = "^0.1.2"
 aiohttp = "^3.6.2"
+numpy = "^1.20"
+statsmodels = "^0.14"
 
 [tool.poetry.dev-dependencies]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ aiohttp
 aiohttp_proxy
 pyyaml
 tqdm
+numpy
+statsmodels

--- a/tests/test_forecast_service.py
+++ b/tests/test_forecast_service.py
@@ -1,0 +1,43 @@
+import math
+import pytest
+from cthulhu_src.services.forecast import ForecastService
+
+
+def test_forecast_constant_returns():
+    prices = [2**i for i in range(70)]
+    svc = ForecastService(lookback=60)
+    results = svc.predict(prices, [1, 5])
+    assert len(results) == 2
+    for res in results:
+        assert math.isclose(res.mu, math.log(2), rel_tol=1e-9)
+        assert math.isclose(res.sigma, 0.0, abs_tol=1e-12)
+        assert math.isclose(res.q10, math.log(2), rel_tol=1e-9)
+        assert math.isclose(res.q50, math.log(2), rel_tol=1e-9)
+        assert math.isclose(res.q90, math.log(2), rel_tol=1e-9)
+
+
+def test_forecast_not_enough():
+    svc = ForecastService(lookback=10)
+    with pytest.raises(ValueError):
+        svc.predict([1, 2, 3], [1])
+
+
+def test_backtest_minutes_back():
+    prices = [2**i for i in range(200)]
+    svc = ForecastService(lookback=60)
+    assert svc.backtest(prices, horizon=5, minutes_back=120) is True
+
+
+def test_predict_many():
+    prices = [2**i for i in range(70)]
+    svc = ForecastService(lookback=60)
+    results = svc.predict_many(prices, [1, 5], ["mean", "ema", "arima"])
+    assert set(results.keys()) == {"mean", "ema", "arima"}
+    assert len(results["mean"]) == 2
+
+
+def test_arima_constant_returns():
+    prices = [2**i for i in range(70)]
+    svc = ForecastService(lookback=60)
+    res = svc.predict(prices, [1], method="arima")[0]
+    assert math.isclose(res.mu, math.log(2), rel_tol=1e-2)


### PR DESCRIPTION
## Summary
- implement optional ARIMA model in `ForecastService`
- include `statsmodels` dependency
- document new CLI usage for ARIMA forecasting
- extend tests to cover ARIMA predictions

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688cfbfadb0c83338dd398d8ad32fa33